### PR TITLE
Add lighter brushes for dark mode and update tab styles

### DIFF
--- a/MySchool/App.xaml
+++ b/MySchool/App.xaml
@@ -23,6 +23,11 @@
         <SolidColorBrush x:Key="Brush.Background" Color="#F5F7FB"/>
         <SolidColorBrush x:Key="Brush.TextPrimary" Color="#0F172A"/>
         <SolidColorBrush x:Key="Brush.TextSecondary" Color="#475569"/>
+        <!-- Lightened text brush for dark mode -->
+        <SolidColorBrush x:Key="Brush.TextPrimaryLighter" Color="#FFFFFF"/>
+
+        <!-- Lightened card background for dark mode -->
+        <SolidColorBrush x:Key="Brush.CardLighter" Color="#2b3242"/>
 
         <!-- Typography helpers -->
         <Style x:Key="Text.Headline" TargetType="TextBlock">

--- a/MySchool/MainWindow.xaml
+++ b/MySchool/MainWindow.xaml
@@ -60,16 +60,16 @@
                 </StackPanel>
 
                 <!-- Center tab icons: Schedule | Home | Settings -->
-                <Border Style="{StaticResource Card}" Grid.Column="2" CornerRadius="18" Padding="6,2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Border Style="{StaticResource Card}" Grid.Column="2" CornerRadius="18" Padding="6,2" HorizontalAlignment="Center" VerticalAlignment="Center" Background="{DynamicResource Brush.CardLighter}">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" >
                         <Button x:Name="ScheduleTab" Style="{StaticResource CaptionButton}" Click="ScheduleTab_Click" ToolTip="Schedule" Margin="2,0">
-                            <TextBlock x:Name="ScheduleTabIcon" FontFamily="Segoe MDL2 Assets" FontSize="14" Text="&#xE163;" Foreground="{StaticResource Brush.TextSecondary}"/>
+                            <TextBlock x:Name="ScheduleTabIcon" FontFamily="Segoe MDL2 Assets" FontSize="14" Text="&#xE163;" Foreground="{DynamicResource Brush.TextPrimaryLighter}"/>
                         </Button>
                         <Button x:Name="HomeTab" Style="{StaticResource CaptionButton}" Click="HomeTab_Click" ToolTip="Home" Margin="2,0">
-                            <TextBlock x:Name="HomeTabIcon" FontFamily="Segoe MDL2 Assets" FontSize="14" Text="&#xE80F;" Foreground="{StaticResource Brush.TextSecondary}"/>
+                            <TextBlock x:Name="HomeTabIcon" FontFamily="Segoe MDL2 Assets" FontSize="14" Text="&#xE80F;" Foreground="{DynamicResource Brush.TextPrimaryLighter}"/>
                         </Button>
                         <Button x:Name="SettingsTab" Style="{StaticResource CaptionButton}" Click="SettingsTab_Click" ToolTip="Settings" Margin="2,0">
-                            <TextBlock x:Name="SettingsTabIcon" FontFamily="Segoe MDL2 Assets" FontSize="14" Text="&#xE713;" Foreground="{StaticResource Brush.TextSecondary}"/>
+                            <TextBlock x:Name="SettingsTabIcon" FontFamily="Segoe MDL2 Assets" FontSize="14" Text="&#xE713;" Foreground="{DynamicResource Brush.TextPrimaryLighter}"/>
                         </Button>
                     </StackPanel>
                 </Border>


### PR DESCRIPTION
Introduced new SolidColorBrush resources for lighter text and card backgrounds to support dark mode. Updated MainWindow.xaml to use these new brushes for the center tab icons and card background, improving visual clarity in dark mode.