### PR TITLE
Add BOM to copilot-instructions.md

### DIFF
--- a/MySchool/.github/copilot-instructions.md
+++ b/MySchool/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for MySchool
+﻿# Copilot Instructions for MySchool
 
 ## Project Overview
 MySchool is a WPF application for managing and displaying student and class information. The main UI and logic reside in `MainWindow.xaml` and `MainWindow.xaml.cs`. Application-level configuration is handled in `App.xaml` and `App.xaml.cs`.


### PR DESCRIPTION
A byte order mark (BOM) was added to the beginning of the copilot-instructions.md file, likely to improve compatibility with certain editors or tools that expect UTF-8 BOM.