### PR TITLE
fix margin of hero section on home page

### DIFF
--- a/MySchool/Pages/Home.xaml
+++ b/MySchool/Pages/Home.xaml
@@ -62,7 +62,7 @@
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"
                                    Text="&#xEB68;"
-                                   Margin="20,0,0,0"/>
+                                   Margin="0,0,20,0"/>
                     </Grid>
                 </Border>
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout of the Home page. The margin for a text element has been changed to shift spacing from the left to the right, improving the alignment and appearance of the UI.

- Changed the `Margin` property of a text element in `Home.xaml` from `20,0,0,0` to `0,0,20,0` to move the spacing from the left side to the right.