### PR TITLE
When clicked, schedule card on home page now navigates to the schedule tab

### DIFF
--- a/MySchool/Pages/Home.xaml
+++ b/MySchool/Pages/Home.xaml
@@ -120,7 +120,7 @@
             <StackPanel Orientation="Vertical" Margin="0,0,0,16">
                 <WrapPanel ItemWidth="220" ItemHeight="100" MinWidth="220" HorizontalAlignment="Left" Margin="0,0,0,15">
                     <!-- Action card 1 -->
-                    <Border Style="{StaticResource Card}" Width="200" Height="100" HorizontalAlignment="Center">
+                    <Border Style="{StaticResource Card}" Width="200" Height="100" HorizontalAlignment="Center" Cursor="Hand" MouseLeftButtonDown="ScheduleCard_Click">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Style="{StaticResource Icon}" Text="&#xF763;" HorizontalAlignment="Center"/>

--- a/MySchool/Pages/Home.xaml.cs
+++ b/MySchool/Pages/Home.xaml.cs
@@ -358,5 +358,20 @@ namespace MySchool.Pages
                 System.Diagnostics.Debug.WriteLine($"Exception in TryRenderUpcomingEvents: {ex}");
             }
         }
+
+        private void ScheduleCard_Click(object sender, MouseButtonEventArgs e)
+        {
+            // Navigate to the Schedule tab
+            var mainWindow = Window.GetWindow(this) as MainWindow;
+            if (mainWindow != null)
+            {
+                // Find the Schedule tab button and trigger its click
+                var scheduleTab = mainWindow.FindName("ScheduleTab") as Button;
+                if (scheduleTab != null)
+                {
+                    scheduleTab.RaiseEvent(new RoutedEventArgs(System.Windows.Controls.Primitives.ButtonBase.ClickEvent));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request adds a user interaction to the Home page, allowing users to navigate directly to the Schedule tab by clicking the first action card. The main changes are:

**User Interaction Improvements:**

* Added a `Cursor="Hand"` and a `MouseLeftButtonDown` event handler (`ScheduleCard_Click`) to the first action card's `Border` in `Home.xaml`, making it visually clickable and interactive.

**Navigation Logic:**

* Implemented the `ScheduleCard_Click` method in `Home.xaml.cs` to programmatically trigger the click event on the Schedule tab button (`ScheduleTab`), enabling navigation to the Schedule tab when the card is clicked.…hedule card to navigate to Schedule tab