### PR TITLE
Show after-school greeting and weather on Home page

### DIFF
--- a/MySchool/Classes/TimetableManager.cs
+++ b/MySchool/Classes/TimetableManager.cs
@@ -147,6 +147,46 @@ namespace MySchool.Classes
                 return (null, null);
             }
         }
+
+        // Returns true if the current time is after the last period's end time for today.
+        public static bool IsAfterLastPeriodForToday()
+        {
+            try
+            {
+                var timetable = LoadLatestTimetable();
+                if (timetable == null)
+                    return false;
+
+                var todayName = DateTime.Now.DayOfWeek.ToString();
+                var todaySchedule = timetable.Timetable.FirstOrDefault(d =>
+                    d.Day.Equals(todayName, StringComparison.OrdinalIgnoreCase));
+
+                if (todaySchedule == null || todaySchedule.Periods == null || todaySchedule.Periods.Count == 0)
+                    return false;
+
+                // Find the maximum valid end time across all periods (classes and breaks)
+                TimeSpan? lastEnd = null;
+                foreach (var p in todaySchedule.Periods)
+                {
+                    if (TimeSpan.TryParse(p.EndTime, out var end))
+                    {
+                        if (lastEnd == null || end > lastEnd)
+                        {
+                            lastEnd = end;
+                        }
+                    }
+                }
+
+                if (lastEnd == null)
+                    return false;
+
+                return DateTime.Now.TimeOfDay >= lastEnd.Value;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }
 

--- a/MySchool/Pages/Home.xaml.cs
+++ b/MySchool/Pages/Home.xaml.cs
@@ -39,7 +39,7 @@ namespace MySchool.Pages
             // Load weather once or display cached data
             if (!hasLoadedWeather)
             {
-                await LoadWeatherIfWeekendAsync();
+                await LoadWeatherIfWeekendOrAfterSchoolAsync();
                 hasLoadedWeather = true;
             }
             else if (cachedWeather != null)
@@ -79,18 +79,20 @@ namespace MySchool.Pages
         {
             var today = DateTime.Now.DayOfWeek;
             bool isWeekend = today == DayOfWeek.Saturday || today == DayOfWeek.Sunday;
+            bool isAfterSchool = !isWeekend && TimetableManager.IsAfterLastPeriodForToday();
 
-            if (isWeekend)
+            if (isWeekend || isAfterSchool)
             {
-                // Hide current class section on weekends
+                // Hide current class section on weekends or after school
                 CurrentClassBorder.Visibility = Visibility.Collapsed;
                 LeftColumn.Width = new GridLength(0);
                 
                 // Adjust greeting border margin to expand left
                 GreetingBorder.Margin = new Thickness(0, 0, 20, 0);
                 
-                // Update center greeting for weekend
-                MainGreeting.Text = today == DayOfWeek.Saturday ? "Happy Saturday!" : "Happy Sunday!";
+                // Update center greeting for weekend/after-school: two words only, add '!'
+                var dayName = today.ToString();
+                MainGreeting.Text = $"Happy {dayName}!";
                 
                 // Show weekend content in right section (weather)
                 NextClassPanel.Visibility = Visibility.Collapsed;
@@ -117,12 +119,13 @@ namespace MySchool.Pages
             }
         }
 
-        private async Task LoadWeatherIfWeekendAsync()
+        private async Task LoadWeatherIfWeekendOrAfterSchoolAsync()
         {
             var today = DateTime.Now.DayOfWeek;
             bool isWeekend = today == DayOfWeek.Saturday || today == DayOfWeek.Sunday;
+            bool isAfterSchool = !isWeekend && TimetableManager.IsAfterLastPeriodForToday();
 
-            if (!isWeekend)
+            if (!isWeekend && !isAfterSchool)
                 return;
 
             try
@@ -253,9 +256,10 @@ namespace MySchool.Pages
             {
                 var today = DateTime.Now.DayOfWeek;
                 bool isWeekend = today == DayOfWeek.Saturday || today == DayOfWeek.Sunday;
+                bool isAfterSchool = !isWeekend && TimetableManager.IsAfterLastPeriodForToday();
 
-                // Skip loading class info on weekends
-                if (isWeekend)
+                // Skip loading class info on weekends or after school
+                if (isWeekend || isAfterSchool)
                 {
                     return;
                 }

--- a/MySchool/Windows/TimetableUploadDialog.xaml.cs
+++ b/MySchool/Windows/TimetableUploadDialog.xaml.cs
@@ -124,7 +124,7 @@ namespace MySchool.Windows
             try
             {
                 Clipboard.SetText(PromptTextBox.Text);
-                CopyPromptButton.Content = "? Copied!";
+                CopyPromptButton.Content = "Copied!";
                 
                 // Reset button text after 2 seconds
                 var timer = new System.Windows.Threading.DispatcherTimer


### PR DESCRIPTION
This pull request adds support for "after school" detection in the home page logic, ensuring that the UI and weather data behave similarly after the last period of the day as they do on weekends. The changes are focused on improving the user experience by hiding class information and updating greetings and weather when the school day has ended, not just on weekends.

**After school detection and UI updates:**

* Added the new method `IsAfterLastPeriodForToday()` in `TimetableManager.cs` to determine if the current time is after the last scheduled period for today.
* Updated `ConfigureWeekendLayout()` in `Home.xaml.cs` to also apply weekend-style UI changes after school hours, including hiding the current class section and updating the greeting to "Happy {Day}!".
* Modified `LoadCurrentAndNextClass()` in `Home.xaml.cs` to skip loading class info not only on weekends but also after school.

**Weather loading logic improvements:**

* Renamed and updated `LoadWeatherIfWeekendAsync()` to `LoadWeatherIfWeekendOrAfterSchoolAsync()` in `Home.xaml.cs`, and changed its logic to also load weather after school hours, not just on weekends. [[1]](diffhunk://#diff-0580eacaf5abd912f128e8dcb1ae4015d0aca96608011263d09e5317d899f678L120-R128) [[2]](diffhunk://#diff-0580eacaf5abd912f128e8dcb1ae4015d0aca96608011263d09e5317d899f678L42-R42)

**Minor UI fix:**

* Changed the copy prompt button text in `TimetableUploadDialog.xaml.cs` from "? Copied!" to "Copied!" for clarity.Added IsAfterLastPeriodForToday to TimetableManager to detect when the school day has ended. Updated Home.xaml.cs to display a 'Happy <Day>!' greeting and show weather information after school hours, similar to weekends. Also fixed the copy button text in TimetableUploadDialog.