### PR TITLE
Improve update check error handling and messages

### DIFF
--- a/MySchool/Pages/Settings.xaml.cs
+++ b/MySchool/Pages/Settings.xaml.cs
@@ -270,8 +270,23 @@ namespace MySchool.Pages
             catch (Exception ex)
             {
                 checkingDialog.Close();
+                
+                // Provide detailed error message based on exception type
+                string errorMessage = ex.Message;
+                
+                // Add helpful suggestions based on the error
+                if (errorMessage.Contains("internet connection") || 
+                     errorMessage.Contains("timed out") || 
+                     errorMessage.Contains("connect"))
+                {
+                    errorMessage += "\n\nPlease ensure:\n" +
+                                   "• You are connected to the internet\n" +
+                                   "• Your firewall isn't blocking the connection\n" +
+                                   "• GitHub.com is accessible from your network";
+                }
+        
                 MessageBox.Show(
-                    $"Failed to check for updates: {ex.Message}\n\nPlease check your internet connection and try again.",
+                    errorMessage,
                     "Update Check Failed",
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);


### PR DESCRIPTION
This pull request improves the update checking experience in the application by enhancing error handling and providing more helpful feedback to users. The main focus is on making network-related update failures clearer and easier to troubleshoot.

**Error handling and user feedback improvements:**

* Added specific catch blocks for `WebException`, `HttpRequestException`, and `TaskCanceledException` in `App.xaml.cs` to provide more detailed error messages and diagnostics when update checks fail due to network issues.
* Updated the error dialog in `Settings.xaml.cs` to display more helpful suggestions to users (such as checking internet connection, firewall settings, and GitHub accessibility) when update checks fail for connectivity reasons.

**Update mechanism adjustment:**

* Changed the update manager initialization to use `GithubSource` instead of a direct URL, aligning with best practices for GitHub-based updates.

Enhanced exception handling in update check logic to provide more specific error messages for network, HTTP, and timeout issues. Updated the Settings page to display more helpful troubleshooting suggestions to users when update checks fail.